### PR TITLE
samples: rpmsg-simple-nrf5340: add net as child image

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+set(ZEPHYR_EXTRA_MODULES ${CMAKE_CURRENT_LIST_DIR})
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -27,3 +27,10 @@ config DUALCORE_RPMSG_NRF53_RX_STACK_SIZE
 config DUALCORE_RPMSG_NRF53_RX_PRIO
 	int "RPMsg RX thread priority"
 	default 8
+
+config INCLUDE_NET_IMAGE
+        bool "include net image as sub image"
+        depends on SOC_NRF5340_CPUAPP
+        default y if (BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS)
+        select PARTITION_MANAGER_ENABLED
+        select BOARD_ENABLE_CPUNET

--- a/app/aci/CMakeLists.txt
+++ b/app/aci/CMakeLists.txt
@@ -1,0 +1,11 @@
+# This check is needed to avoid infinite recursion. This module code will
+# be executed for all images in the build, also for the child image being
+# added below.
+if (CONFIG_INCLUDE_NET_IMAGE)
+  add_child_image(
+    NAME net_core
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../net
+    DOMAIN cpunet
+    BOARD nrf5340dk_nrf5340_cpunet
+    )
+endif()

--- a/app/zephyr/module.yml
+++ b/app/zephyr/module.yml
@@ -1,0 +1,5 @@
+# Point to the 'aci' directory (relative to the sample directory) since this
+# contains the CMakeLists.txt that adds the child image.
+
+build:
+  cmake: aci


### PR DESCRIPTION
add "net" as a child-image when building for
the nrf5340dk_nrf5340_cpuapp board.

Signed-off-by: Håkon Alseth <haal@nordicsemi.no>